### PR TITLE
Work with newer version of Kafka Connect Maven plugin for CC-2213

### DIFF
--- a/src/com/github/jcustenborder/jenkins/pipeline/KafkaConnectPipeline.groovy
+++ b/src/com/github/jcustenborder/jenkins/pipeline/KafkaConnectPipeline.groovy
@@ -120,7 +120,9 @@ def execute() {
                 echo 'Stashing target/confluent-docs/**/**'
                 stash includes: 'target/confluent-docs/**/**', name: 'confluent-docs', allowEmpty: true
                 echo 'Stashing target/plugins/packages/*.zip'
-                stash includes: 'target/plugins/packages/*.zip', name: 'plugin', allowEmpty: true
+                stash includes: 'target/plugins/packages/*.zip', name: 'plugin-old', allowEmpty: true
+                echo 'Stashing target/components/packages/*.zip'
+                stash includes: 'target/components/packages/*.zip', name: 'plugin', allowEmpty: true
             }
         }
     }
@@ -155,17 +157,31 @@ def execute() {
         archiveArtifacts artifacts: "target/${artifactId}-${version}.*"
         archiveArtifacts artifacts: "target/docs/**/*"
         archiveArtifacts artifacts: "target/plugins/packages/*.zip", allowEmptyArchive: true
+        archiveArtifacts artifacts: "target/components/packages/*.zip", allowEmptyArchive: true
         archiveArtifacts artifacts: "target/confluent-docs/**/**", allowEmptyArchive: true
 
         if (env.BRANCH_NAME == 'master') {
             stage('publish') {
                 if (fileExists('target/plugins/packages')) {
+                    // Old (0.9) version of the Kafka Connect Maven packaging plugin
                     dir('target/plugins/packages') {
                         def zipFileName = "jcustenborder-${artifactId}-${version}-plugin.zip"
                         if(fileExists(zipFileName)) {
                             uploadPlugin(zipFileName, 'jcustenborder', artifactId, version)
                         }
                         zipFileName = "confluentinc-${artifactId}-${version}-plugin.zip"
+                        if(fileExists(zipFileName)) {
+                            uploadPlugin(zipFileName, 'confluentinc', artifactId, version)
+                        }
+                    }
+                } else if (fileExists('target/components/packages')) {
+                    // New (0.10+) version of the Kafka Connect Maven packaging plugin
+                    dir('target/components/packages') {
+                        def zipFileName = "jcustenborder-${artifactId}-${version}.zip"
+                        if(fileExists(zipFileName)) {
+                            uploadPlugin(zipFileName, 'jcustenborder', artifactId, version)
+                        }
+                        zipFileName = "confluentinc-${artifactId}-${version}.zip"
                         if(fileExists(zipFileName)) {
                             uploadPlugin(zipFileName, 'confluentinc', artifactId, version)
                         }


### PR DESCRIPTION
This change adds support for the newer archive naming format, which dropped the '-plugin' suffix. It uses the name of the directory in which the archive is stored to infer which name the archive file should have; when the change was made that dropped the '-plugin' suffix from archive files, the directory for the archive was changed from `target/plugins/packages` to `target/components/packages`.