### PR TITLE
Update S3 keys for Confluent Hub components

### DIFF
--- a/src/com/github/jcustenborder/jenkins/pipeline/ConfluentConnectHub.groovy
+++ b/src/com/github/jcustenborder/jenkins/pipeline/ConfluentConnectHub.groovy
@@ -37,13 +37,13 @@ class ConfluentConnectHub implements Serializable {
                                 acl: 'Private',
                                 file: "${zipFile.path}",
                                 bucket: "${env.BUCKET}",
-                                path: "${owner}/${artifactId}/${version}/${zipFile.name}"
+                                path: "api/plugins/${owner}/${artifactId}/versions/${version}/${zipFile.name}"
                         )
                         this.steps.s3Upload(
                                 acl: 'Private',
                                 file: "${manifestPath.path}",
                                 bucket: "${env.BUCKET}",
-                                path: "${owner}/${artifactId}/${version}/manifest.json"
+                                path: "api/plugins/${owner}/${artifactId}/versions/${version}/manifest.json"
                         )
                     }
                 }


### PR DESCRIPTION
We've had to alter the key format used in S3 for Confluent Hub components in order to support CloudFront without breaking backwards compatibility with previously-released versions of the `confluent-hub` client. This PR alters the upload path for Confluent Hub components so that they will be properly recognized by the back end service.